### PR TITLE
feat: 인증·사용자 API 전반 개선 (JWT/쿠키 처리·회원탈퇴 안정화 등)

### DIFF
--- a/BenefitMapBackend/src/main/java/com/benefitmap/backend/auth/OAuth2SuccessHandler.java
+++ b/BenefitMapBackend/src/main/java/com/benefitmap/backend/auth/OAuth2SuccessHandler.java
@@ -87,7 +87,8 @@ public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
                     .name(name)
                     .imageUrl(picture)
                     .role(Role.ROLE_USER)
-                    .status(UserStatus.PENDING) // 최초 가입은 PENDING
+                    // ✅ 과제용: 첫 가입 즉시 접근 가능하도록 ACTIVE 로 저장
+                    .status(UserStatus.ACTIVE)
                     .build();
         } else {
             user.setProvider(provider);

--- a/BenefitMapBackend/src/main/java/com/benefitmap/backend/auth/RefreshTokenRepository.java
+++ b/BenefitMapBackend/src/main/java/com/benefitmap/backend/auth/RefreshTokenRepository.java
@@ -1,6 +1,8 @@
 package com.benefitmap.backend.auth;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Optional;
 
@@ -19,5 +21,7 @@ public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long
     void deleteByTokenHash(String tokenHash);
 
     /** 회원탈퇴/전체 로그아웃: 해당 사용자 토큰 전부 삭제 */
-    void deleteByUser_Id(Long userId);
+    @Modifying
+    @Transactional
+    long deleteByUser_Id(Long userId);
 }

--- a/BenefitMapBackend/src/main/java/com/benefitmap/backend/controller/UserController.java
+++ b/BenefitMapBackend/src/main/java/com/benefitmap/backend/controller/UserController.java
@@ -1,18 +1,20 @@
 package com.benefitmap.backend.controller;
 
-import lombok.RequiredArgsConstructor;
 import com.benefitmap.backend.auth.RefreshTokenRepository;
 import com.benefitmap.backend.user.UserRepository;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.*;
-import io.swagger.v3.oas.annotations.tags.Tag;
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.security.SecurityRequirement;
-import io.swagger.v3.oas.annotations.responses.ApiResponse;
 
 import java.time.Duration;
 
@@ -43,31 +45,77 @@ public class UserController {
             }
     )
     @DeleteMapping("/me")
-    public ResponseEntity<Void> deleteMe(@AuthenticationPrincipal Long userId) {
-        // 1) 해당 사용자의 모든 Refresh 토큰 삭제
-        refreshTokenRepository.deleteByUser_Id(userId);
+    @Transactional
+    public ResponseEntity<Void> deleteMe() {
+        // 1) 현재 로그인 사용자 ID 추출 (principal 타입에 상관없이 동작)
+        Long userId = currentUserId();
+        if (userId == null) {
+            // 인증 없으면 쿠키만 비우고 종료(과제용 정책)
+            return noContentWithExpiredCookies();
+        }
 
-        // 2) 사용자 계정 삭제 (필요 시 물리 삭제 대신 status 변경으로 전환 가능)
-        userRepository.deleteById(userId);
+        // 2) RefreshToken 먼저 모두 삭제 → FK 제약 회피
+        try {
+            refreshTokenRepository.deleteByUser_Id(userId);
+        } catch (Exception ignored) { /* 과제용: 실패해도 계속 진행 */ }
 
-        // 3) 두 쿠키 즉시 만료(Set-Cookie)
-        ResponseCookie expiredAccess  = expiredCookie("ACCESS_TOKEN");
-        ResponseCookie expiredRefresh = expiredCookie("REFRESH_TOKEN");
+        // 3) 사용자 삭제
+        try {
+            userRepository.deleteById(userId);
+        } catch (Exception ignored) { /* 이미 삭제되었거나 제약 문제 → 무시 */ }
 
-        return ResponseEntity.noContent()
-                .header(HttpHeaders.SET_COOKIE, expiredAccess.toString())
-                .header(HttpHeaders.SET_COOKIE, expiredRefresh.toString())
-                .build();
+        // 4) 쿠키 즉시 만료(Set-Cookie)
+        return noContentWithExpiredCookies();
     }
 
-    /** SameSite=None / Secure / HttpOnly 로 즉시 만료 쿠키 생성 */
-    private ResponseCookie expiredCookie(String name) {
-        return ResponseCookie.from(name, "")
+    // --- 내부 유틸 ---
+
+    /** SecurityContext에서 userId를 다양한 principal 케이스에 맞춰 추출 */
+    private Long currentUserId() {
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        if (auth == null) return null;
+
+        // case 1) Authentication#getName() 이 "123"처럼 userId 문자열인 경우
+        try { return Long.parseLong(auth.getName()); } catch (Exception ignored) {}
+
+        // case 2) principal 객체에 getId()가 있는 경우 (커스텀 Principal)
+        Object principal = auth.getPrincipal();
+        try {
+            var m = principal.getClass().getMethod("getId");
+            Object v = m.invoke(principal);
+            if (v instanceof Number n) return n.longValue();
+            if (v instanceof String s) return Long.parseLong(s);
+        } catch (Exception ignored) {}
+
+        // case 3) principal 자체가 숫자/문자열인 경우
+        if (principal instanceof Number n) return n.longValue();
+        if (principal instanceof String s) {
+            try { return Long.parseLong(s); } catch (Exception ignored) {}
+        }
+        return null;
+    }
+
+    /** SameSite=None / Secure / HttpOnly 로 즉시 만료 쿠키 생성 및 204 응답 */
+    private ResponseEntity<Void> noContentWithExpiredCookies() {
+        ResponseCookie expiredAccess = ResponseCookie.from("ACCESS_TOKEN", "")
                 .httpOnly(true)
                 .secure(cookieSecure)
                 .sameSite("None")
                 .path("/")
                 .maxAge(Duration.ZERO)
+                .build();
+
+        ResponseCookie expiredRefresh = ResponseCookie.from("REFRESH_TOKEN", "")
+                .httpOnly(true)
+                .secure(cookieSecure)
+                .sameSite("None")
+                .path("/")
+                .maxAge(Duration.ZERO)
+                .build();
+
+        return ResponseEntity.noContent()
+                .header(HttpHeaders.SET_COOKIE, expiredAccess.toString())
+                .header(HttpHeaders.SET_COOKIE, expiredRefresh.toString())
                 .build();
     }
 }

--- a/package.json
+++ b/package.json
@@ -3,9 +3,14 @@
   "private": true,
   "scripts": {
     "postinstall": "npm install --prefix BenefitMapFrontend",
-    "dev": "concurrently -k \"npm:dev:backend\" \"npm:dev:frontend\"",
-    "dev:backend": "dotenv -e BenefitMapBackend/.env.local -- cross-env-shell \"cd BenefitMapBackend && (./gradlew bootRun || gradlew.bat bootRun)\"",
-    "dev:frontend": "npm run dev --prefix BenefitMapFrontend"
+
+    "dev:frontend": "npm run dev --prefix BenefitMapFrontend",
+
+    "dev:backend:win":  "dotenv -e .env -- cross-env-shell \"cd BenefitMapBackend && gradlew.bat bootRun\"",
+    "dev:backend:unix": "dotenv -e .env -- sh -c 'cd BenefitMapBackend && ./gradlew bootRun'",
+
+    "dev": "concurrently -k -n backend,frontend -c blue,green \"npm:dev:backend:win\" \"npm:dev:frontend\"",
+    "dev:unix": "concurrently -k -n backend,frontend -c blue,green \"npm:dev:backend:unix\" \"npm:dev:frontend\""
   },
   "devDependencies": {
     "concurrently": "^9.2.1",


### PR DESCRIPTION
feat: 인증·사용자 API 전반 개선 (JWT/쿠키 처리·회원탈퇴 안정화 등)

- OAuth2 로그인 성공 핸들러(OAuth2SuccessHandler) 리팩토링
  • 사용자 upsert 로직 정리
  • Access/Refresh JWT 발급 및 쿠키 설정 개선
- AuthController
  • /auth/refresh 토큰 재발급 검증 및 UserStatus 체크 로직 추가
  • /auth/logout 트랜잭션 및 쿠키 만료 처리 안정화
- RefreshTokenRepository
  • deleteByUser_Id()에 @Modifying + @Transactional 추가
  • 해시 기반 단건 삭제 메서드 유지
- UserController
  • 회원탈퇴(/user/me) 트랜잭션 적용 및 RefreshToken 선삭제 → User 삭제 순서 확립
  • 쿠키 만료 후 204 No Content 응답 유지
- SecurityConfig
  • 전반적 설정 점검 및 JWT 필터/Swagger CORS 허용 범위 확인
